### PR TITLE
build(npm): change package to be scoped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storage-utils",
+  "name": "@martini97/storage-utils",
   "version": "0.0.0-development",
   "description": "Wrapper around window.localStorage",
   "main": "dist/index.js",
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/martini97/storage-utils.git"
+    "url": "git+https://github.com/martini97/storage-utils.git"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint"
@@ -56,5 +56,8 @@
     "branches": [
       "main"
     ]
+  },
+  "bugs": {
+    "url": "https://github.com/martini97/storage-utils/issues"
   }
 }


### PR DESCRIPTION
There's already a package listed as `storage-utils`