### PR TITLE
fix(event): event base name was undefined on some applications

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -3,7 +3,14 @@ interface CustomStorageEventData {
   value: unknown;
 }
 
-export const eventId = `${process.env.npm_package_name}:__storage__`;
+const createEventId = (): string => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const package_ = require('../package.json');
+  const baseName = process.env.npm_package_name || package_.name;
+  return `${baseName}:__storage__`;
+};
+
+export const eventId = createEventId();
 
 export function dispatch(key: string, value: unknown): void {
   const event = new CustomEvent<CustomStorageEventData>(eventId, {

--- a/tests/event.spec.ts
+++ b/tests/event.spec.ts
@@ -1,0 +1,5 @@
+import {eventId} from '../src/event';
+
+it('eventId', () => {
+  expect(eventId).toBe('@martini97/storage-utils:__storage__');
+});


### PR DESCRIPTION
Some CRA apps do not define the `process.env.npm_package_name` which caused the eventId to become
`undefined:__storage__`, to prevent this we are falling back to the storage-utils package name.
